### PR TITLE
Reorder the Dockerfile to squeeze slightly more out of the Docker build cache for each update of fsharp

### DIFF
--- a/4.0.0.4/Dockerfile
+++ b/4.0.0.4/Dockerfile
@@ -1,22 +1,28 @@
 FROM buildpack-deps:trusty
 MAINTAINER Henrik Feldt
 
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+    echo "deb http://download.mono-project.com/repo/debian wheezy main" > /etc/apt/sources.list.d/mono-xamarin.list && \
+    echo "deb http://download.mono-project.com/repo/debian alpha main" > /etc/apt/sources.list.d/mono-xamarin-alpha.list
+
+RUN apt-get -y update && \
+    apt-get -y --no-install-recommends install nuget && \
+    rm -rf /var/lib/apt/lists/*
+
 ENV MONO_VERSION 4.2.1.102
-ENV FSHARP_VERSION 4.0.0.4
+
+RUN apt-get -y update && \
+    apt-get -y --no-install-recommends install mono-devel=$MONO_VERSION-0xamarin1 ca-certificates-mono=$MONO_VERSION-0xamarin1 && \
+    rm -rf /var/lib/apt/lists/*
+
 ENV FSHARP_PREFIX /usr
 ENV FSHARP_GACDIR /usr/lib/mono/gac
+ENV FSHARP_VERSION 4.0.0.4
 ENV FSHARP_BASENAME fsharp-$FSHARP_VERSION
 ENV FSHARP_ARCHIVE $FSHARP_VERSION.tar.gz
 ENV FSHARP_ARCHIVE_URL https://github.com/fsharp/fsharp/archive/$FSHARP_ARCHIVE
 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
-    echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list && \
-    echo "deb http://download.mono-project.com/repo/debian alpha main" | sudo tee /etc/apt/sources.list.d/mono-xamarin-alpha.list && \
-    apt-get -y update && \
-    apt-get -y --no-install-recommends install mono-devel=$MONO_VERSION-0xamarin1 ca-certificates-mono=$MONO_VERSION-0xamarin1 nuget libtool make automake wget && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    mkdir -p /tmp/src && \
+RUN mkdir -p /tmp/src && \
     cd /tmp/src && \
     wget $FSHARP_ARCHIVE_URL && \
     tar xf $FSHARP_ARCHIVE && \
@@ -27,5 +33,4 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
     cd ~ && \
     rm -rf /tmp/src
 
-ENTRYPOINT ["/bin/bash"]
 CMD ["fsharpi"]


### PR DESCRIPTION
This helps ensure that a more minimal number of actual image layers need to be re-pulled when fsharp itself gets a bump (and hopefully means that if multiple versions of fsharp are ever concurrently supported here that they can have more chance of overlapping shared layers).

This is in response to the official review of the image for https://github.com/docker-library/official-images/pull/1201 (figured a PR would be easier to digest and communicate about than going back and forth on the PR thread there in long-form prose).

Any particular reason you went with Ubuntu as the base instead of Debian like most of the other official images do? (just curious)
