### PR TITLE
rebasing on mono 4.2.3

### DIFF
--- a/4.0.0.4/Dockerfile
+++ b/4.0.0.4/Dockerfile
@@ -1,19 +1,14 @@
 FROM buildpack-deps:trusty
 MAINTAINER Henrik Feldt
 
+ENV MONO_VERSION 4.2.3.4
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
-    echo "deb http://download.mono-project.com/repo/debian wheezy main" > /etc/apt/sources.list.d/mono-xamarin.list && \
-    echo "deb http://download.mono-project.com/repo/debian alpha main" > /etc/apt/sources.list.d/mono-xamarin-alpha.list
+    echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots $MONO_VERSION/main" > /etc/apt/sources.list.d/mono-xamarin.list 
 
-RUN apt-get -y update && \
-    apt-get -y --no-install-recommends install nuget && \
-    rm -rf /var/lib/apt/lists/*
-
-ENV MONO_VERSION 4.2.1.102
 ENV MONO_THREADS_PER_CPU 50
 
 RUN apt-get -y update && \
-    apt-get -y --no-install-recommends install mono-devel=$MONO_VERSION-0xamarin1 ca-certificates-mono=$MONO_VERSION-0xamarin1 && \
+    apt-get -y --force-yes --no-install-recommends install nuget mono-devel ca-certificates-mono && \
     rm -rf /var/lib/apt/lists/*
 
 ENV FSHARP_PREFIX /usr

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ The image contains the latest mono version with F#.
 
 # Dependency versions used:
 
-* Mono 4.2.1.102
+* Mono 4.2.3.4


### PR DESCRIPTION
There seems to be no rhyme or reason to xamarin releases organization, specifying a snapshot works for this release (this is how official mono container does it as well).
