### PR TITLE
Validate checksum for .NET Core SDK

### DIFF
--- a/4.1.18/core/Dockerfile
+++ b/4.1.18/core/Dockerfile
@@ -18,14 +18,20 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.1
+ENV DOTNET_SDK_VERSION 1.0.3
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
-RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
+# Download, validate against checksum (from https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.0.4-1.1.1-sharedfx-SHA.txt),
+# install runtime.
+RUN echo "4477a1592779f439091d8432c456b6f187d7aec8ca016b214f0aa483867c8fdd  dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz" >> dotnetcore-CHECKSUM \
+    && curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
-    && rm dotnet.tar.gz \
+    && sha256sum -c dotnetcore-CHECKSUM \
+    && rm dotnetcore-CHECKSUM \
+    && tar -zxf dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz -C /usr/share/dotnet \
+    && rm dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip
@@ -35,5 +41,3 @@ RUN mkdir warmup \
     && cd .. \
     && rm -rf warmup \
     && rm -rf /tmp/NuGetScratch
-
-ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Also bump to 1.0.3 SDK.

As pointed out in the push for the official images, this `core` image Dockerfile doesn't validate the checksum for the .NET Core SDK.  This PR updates that and also removes a redundant `ENTRYPOINT`.

Also, I see the 1.0.3 SDK is the latest, so using that instead of 1.0.1.