### PR TITLE
Reducing image size by clearing build cache.

### DIFF
--- a/4.1.18/mono-wheezy/Dockerfile
+++ b/4.1.18/mono-wheezy/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:wheezy
+LABEL maintainer "Dave Curylo <dave@curylo.org>, Steve Desmond <steve@stevedesmond.ca>"
+
+ENV MONO_THREADS_PER_CPU 50
+RUN MONO_VERSION=4.8.1.0 && \
+    FSHARP_VERSION=4.1.18 && \
+    FSHARP_PREFIX=/usr && \
+    FSHARP_GACDIR=/usr/lib/mono/gac && \
+    FSHARP_BASENAME=fsharp-$FSHARP_VERSION && \
+    FSHARP_ARCHIVE=$FSHARP_VERSION.tar.gz && \
+    FSHARP_ARCHIVE_URL=https://github.com/fsharp/fsharp/archive/$FSHARP_VERSION.tar.gz && \
+    # See http://download.mono-project.com/repo/debian/dists/wheezy/snapshots/
+    apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+    echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-xamarin.list && \
+    apt-get update -y && \
+    apt-get --no-install-recommends install -y autoconf libtool pkg-config make git automake curl nuget mono-devel ca-certificates-mono && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /tmp/src && \
+    cd /tmp/src && \
+    curl -LO $FSHARP_ARCHIVE_URL && \
+    tar xf $FSHARP_ARCHIVE && \
+    cd $FSHARP_BASENAME && \
+    ./autogen.sh --prefix=$FSHARP_PREFIX --with-gacdir=$FSHARP_GACDIR && \
+    make && \
+    make install && \
+    cd ~ && \
+    rm -rf /tmp/src /tmp/NuGetScratch ~/.nuget ~/.config ~/.local && \
+    apt-get purge -y autoconf libtool make git automake curl
+
+WORKDIR /root
+CMD ["fsharpi"]

--- a/4.1.18/mono/Dockerfile
+++ b/4.1.18/mono/Dockerfile
@@ -1,35 +1,31 @@
 FROM buildpack-deps:trusty
 LABEL maintainer "Dave Curylo <dave@curylo.org>, Steve Desmond <steve@stevedesmond.ca>"
 
-# See http://download.mono-project.com/repo/debian/dists/wheezy/snapshots/
-ENV MONO_VERSION 4.8.1.0
-
-RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
-    echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-xamarin.list
-
 ENV MONO_THREADS_PER_CPU 50
-
-RUN apt-get -y update && \
-    apt-get -y --no-install-recommends install nuget mono-devel ca-certificates-mono && \
-    rm -rf /var/lib/apt/lists/*
-
-ENV FSHARP_VERSION 4.1.18
-ENV FSHARP_PREFIX=/usr \
-    FSHARP_GACDIR=/usr/lib/mono/gac \
-    FSHARP_BASENAME=fsharp-$FSHARP_VERSION \
-    FSHARP_ARCHIVE=$FSHARP_VERSION.tar.gz \
-    FSHARP_ARCHIVE_URL=https://github.com/fsharp/fsharp/archive/$FSHARP_VERSION.tar.gz
-
-RUN mkdir -p /tmp/src && \
+RUN MONO_VERSION=4.8.1.0 && \
+    FSHARP_VERSION=4.1.18 && \
+    FSHARP_PREFIX=/usr && \
+    FSHARP_GACDIR=/usr/lib/mono/gac && \
+    FSHARP_BASENAME=fsharp-$FSHARP_VERSION && \
+    FSHARP_ARCHIVE=$FSHARP_VERSION.tar.gz && \
+    FSHARP_ARCHIVE_URL=https://github.com/fsharp/fsharp/archive/$FSHARP_VERSION.tar.gz && \
+    # See http://download.mono-project.com/repo/debian/dists/wheezy/snapshots/
+    apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+    echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-xamarin.list && \
+    apt-get update -y && \
+    apt-get --no-install-recommends install -y autoconf libtool pkg-config make git automake curl nuget mono-devel ca-certificates-mono && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /tmp/src && \
     cd /tmp/src && \
-    wget $FSHARP_ARCHIVE_URL && \
+    curl -LO $FSHARP_ARCHIVE_URL && \
     tar xf $FSHARP_ARCHIVE && \
     cd $FSHARP_BASENAME && \
     ./autogen.sh --prefix=$FSHARP_PREFIX --with-gacdir=$FSHARP_GACDIR && \
     make && \
     make install && \
     cd ~ && \
-    rm -rf /tmp/src
+    rm -rf /tmp/src /tmp/NuGetScratch ~/.nuget ~/.config ~/.local && \
+    apt-get purge -y autoconf libtool make git automake curl
 
 WORKDIR /root
 CMD ["fsharpi"]


### PR DESCRIPTION
This contains one commit to change the current mono image to clean up the cached assemblies and remove packages that were only used for building F#.  It also reduces the scope of several environment variables so they are _only_ present for the build rather than persisted in the docker image and resulting containers.

It also contains a commit for a new image based on debian wheezy.  This is generally compatible with ubuntu packages, but is a much smaller base OS, resulting in a significantly smaller image.  We should test this and determine if future images should switch to wheezy.

For reference on image sizes with these new Dockerfiles:
```
fsharp-trusty latest 780.5 MB
fsharp-wheezy latest 441.6 MB
```
And the current images:
```
docker.io/fsharp latest 933.4 MB
docker.io/fsharp 4.0.1.1 754.9 MB
```

@haf and @stevedesmond-ca - please take a look if you could.