### PR TITLE
Adding image based on Jessie.

### DIFF
--- a/4.1.18/mono-jessie/Dockerfile
+++ b/4.1.18/mono-jessie/Dockerfile
@@ -1,0 +1,35 @@
+FROM debian:jessie-slim
+LABEL maintainer "Dave Curylo <dave@curylo.org>, Steve Desmond <steve@stevedesmond.ca>"
+
+ENV MONO_THREADS_PER_CPU 50
+RUN MONO_VERSION=4.8.1.0 && \
+    FSHARP_VERSION=4.1.18 && \
+    FSHARP_PREFIX=/usr && \
+    FSHARP_GACDIR=/usr/lib/mono/gac && \
+    FSHARP_BASENAME=fsharp-$FSHARP_VERSION && \
+    FSHARP_ARCHIVE=$FSHARP_VERSION.tar.gz && \
+    FSHARP_ARCHIVE_URL=https://github.com/fsharp/fsharp/archive/$FSHARP_VERSION.tar.gz && \
+    # See http://download.mono-project.com/repo/debian/dists/wheezy/snapshots/
+    apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+    echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official.list && \
+    echo "deb http://download.mono-project.com/repo/debian wheezy-libjpeg62-compat main" > /etc/apt/sources.list.d/mono-compatibility.list && \
+    apt-get update -y && \
+    apt-get --no-install-recommends install -y autoconf libtool pkg-config make automake nuget mono-devel ca-certificates-mono && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /tmp/src && \
+    cd /tmp/src && \
+    printf "namespace a { class b { public static void Main(string[] args) { new System.Net.WebClient().DownloadFile(\"%s\", \"%s\");}}}" $FSHARP_ARCHIVE_URL $FSHARP_ARCHIVE > download-fsharp.cs && \
+    mcs download-fsharp.cs && mono download-fsharp.exe && rm download-fsharp.exe download-fsharp.cs && \
+    tar xf $FSHARP_ARCHIVE && \
+    cd $FSHARP_BASENAME && \
+    ./autogen.sh --prefix=$FSHARP_PREFIX --with-gacdir=$FSHARP_GACDIR && \
+    make && \
+    make install && \
+    cd ~ && \
+    rm -rf /tmp/src /tmp/NuGetScratch ~/.nuget ~/.config ~/.local && \
+    apt-get purge -y autoconf libtool make automake && \
+    apt-get clean
+
+WORKDIR /root
+CMD ["fsharpi"]
+


### PR DESCRIPTION
@haf mentioned that the new image based on `wheezy-slim` has some out of date packages, and requested using `debian:jessie` instead.  The official mono only uses `jessie` for 5.0 releases, but we need to stick to mono 4.8.1 for the time being (see issue #24).  That said, I discussed this with some Xamarin people, and they provided information on a repo that provides compatibility for `jessie` with the 4.8.1 release.  This PR adds a Dockerfile that utilizes `jessie-slim` with the Xamarin official packages that support 4.8.1.

I do not intend to for us to support multiple base OS images long term.  Consider these wheezy and jessie images as release candidates so we can find the best solution going forward, and we will need to communicate our migration to just one mono-based image based on the appropriate OS.

FYI - resulting image sizes:
```
fsharp-trusty 780.5 MB
fsharp-wheezy 381.6 MB
fsharp-jessie 439.2 MB
```