### PR TITLE
Add SDK image with .NET Core.

### DIFF
--- a/4.1.29/netcore/Dockerfile
+++ b/4.1.29/netcore/Dockerfile
@@ -1,0 +1,17 @@
+FROM fsharp
+LABEL maintainer "Dave Curylo <dave@curylo.org>, Steve Desmond <steve@stevedesmond.ca>"
+
+ENV FrameworkPathOverride /usr/lib/mono/4.5/
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y curl libunwind8 gettext apt-transport-https
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg && \
+    echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-jessie-prod jessie main" > /etc/apt/sources.list.d/dotnetdev.list && \
+    apt-get update && apt-get --no-install-recommends install -y dotnet-sdk-2.0.3 && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir warmup && \
+    cd warmup && \
+    dotnet new && \
+    cd .. && \
+    rm -rf warmup && \
+    rm -rf /tmp/NuGetScratch
+WORKDIR /root


### PR DESCRIPTION
Having an image with F#, the mono SDK, and the .NET Core SDK really simplifies the process for building multi-targeted F# applications.  I propose we add this as an official image, also resolving long standing issue #3 by providing a .NET Core image.

Having an image with _only_ .NET Core doesn't make a lot of sense because the F# SDK tooling is pulled from nuget anyway and already part of the .NET Core SDK images, but one with SDK's for both .NET Core and full frameworks is very helpful.