### PR TITLE
Add information about installation and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ image which translates to lower storage-costs and quicker deploys. When that
 bug hits the fan, you want to be able to quickly roll back your version or push
 a fix – which means you benefit from lower image sizes.
 
+# Installation
+
+Once Docker is installed on your machine, type: ```docker pull fsharp``` as root. 
+
+## Docker service on Linux
+
+When ```Cannot connect to the Docker daemon at {..} Is the docker daemon running?``` appears:        
+Run ```systemctl start docker``` in order to start it. In order to autostart the docker service, use ```systemctl enable docker```.
+
 # Dependency versions used:
 
 ## Mono Image

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ a fix – which means you benefit from lower image sizes.
 
 # Installation
 
-Once Docker is installed on your machine, type: ```docker pull fsharp``` as root. 
+Once Docker is installed on your machine, type: `docker pull fsharp` as root. 
 
 ## Docker service on Linux
 
-When ```Cannot connect to the Docker daemon at {..} Is the docker daemon running?``` appears:        
-Run ```systemctl start docker``` in order to start it. In order to autostart the docker service, use ```systemctl enable docker```.
+When `Cannot connect to the Docker daemon at {..} Is the docker daemon running?` appears:        
+Run `systemctl start docker` in order to start it. In order to autostart the docker service, use `systemctl enable docker`.
 
 # Dependency versions used:
 


### PR DESCRIPTION
My distribution won't add or start the docker service to systemd, once installed. I guess that's the case on other distros as well. 
Plus, many people may not be used to Docker yet, so I installed Installation instructions.